### PR TITLE
Added backtick escaping to _hash function

### DIFF
--- a/TestSuite/Fixture/TableCopyTestFixture.php
+++ b/TestSuite/Fixture/TableCopyTestFixture.php
@@ -149,7 +149,7 @@ class TableCopyTestFixture extends CakeTestFixture {
  * @return string
  */
 	protected function _hash($db) {
-		$sourceHash = $db->execute(sprintf('CHECKSUM TABLE %s', $this->table), ['log' => false]);
+		$sourceHash = $db->execute(sprintf('CHECKSUM TABLE `%s`', $this->table), ['log' => false]);
 		return $sourceHash->fetch()->Checksum;
 	}
 


### PR DESCRIPTION
- Added backtick escaping around table names, to allow for tables to have otherwise protected keywords, suchs as 'keys', etc.
